### PR TITLE
Add project documentation (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+## プロジェクト概要
+WearOS向けウォッチフェイスアプリ。DSLを使ってWatch Face Format形式のXMLを生成する。
+
+## ビルド
+```shell
+./gradlew assembleDebug
+./gradlew assembleRelease
+```
+
+## プロジェクト構成
+- `app/` - Android アプリモジュール
+- `build-logic/` - Watch Face Format XML生成用のGradleプラグインとDSL
+
+## 言語・技術
+- Kotlin
+- Gradle (Kotlin DSL)
+- Android Gradle Plugin
+- Watch Face Format (WFF)


### PR DESCRIPTION
## Summary
Added comprehensive project documentation file to provide developers with an overview of the WearOS watch face application and its build system.

## Changes
- Created `CLAUDE.md` with project overview, build instructions, and structure documentation
- Documented the dual-module architecture: Android app module and Gradle plugin/DSL for Watch Face Format XML generation
- Listed key technologies: Kotlin, Gradle Kotlin DSL, Android Gradle Plugin, and Watch Face Format (WFF)
- Included build commands for debug and release variants

## Details
This documentation serves as a quick reference for developers working on the project, explaining:
- The purpose of the application (WearOS watch face using DSL-based XML generation)
- How to build the project using Gradle
- The organization of the codebase into app and build-logic modules
- The technology stack used throughout the project

https://claude.ai/code/session_01UaGrLSL1kGY9bZFdyiCm4x