### PR TITLE
Add AnalogClock DSL support and shape drawing elements

### DIFF
--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimatedImageFormat.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimatedImageFormat.kt
@@ -1,0 +1,7 @@
+package net.matsudamper.watchface.dsl.element
+
+enum class AnimatedImageFormat(val value: String) {
+    AGIF("AGIF"),
+    WEBP("WEBP"),
+    IMAGE("IMAGE"),
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimationChangeDirection.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimationChangeDirection.kt
@@ -1,0 +1,7 @@
+package net.matsudamper.watchface.dsl.element
+
+enum class AnimationChangeDirection(val value: String) {
+    FORWARD("FORWARD"),
+    BACKWARD("BACKWARD"),
+    RANDOM("RANDOM"),
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimationPlayEvent.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/element/AnimationPlayEvent.kt
@@ -1,0 +1,9 @@
+package net.matsudamper.watchface.dsl.element
+
+enum class AnimationPlayEvent(val value: String) {
+    TAP("TAP"),
+    ON_VISIBLE("ON_VISIBLE"),
+    ON_NEXT_SECOND("ON_NEXT_SECOND"),
+    ON_NEXT_MINUTE("ON_NEXT_MINUTE"),
+    ON_NEXT_HOUR("ON_NEXT_HOUR"),
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/HasWatchFaceLayoutElement.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/HasWatchFaceLayoutElement.kt
@@ -3,6 +3,7 @@ package net.matsudamper.watchface.dsl.scope
 import net.matsudamper.watchface.dsl.element.ComplicationSlotSupportedType
 import net.matsudamper.watchface.dsl.element.RenderMode
 import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.animatedimage.PartAnimatedImageScope
 import net.matsudamper.watchface.dsl.scope.clock.AnalogClockScope
 import net.matsudamper.watchface.dsl.scope.clock.DigitalClockScope
 import net.matsudamper.watchface.dsl.scope.complication.ComplicationSlotScope
@@ -12,8 +13,6 @@ import net.matsudamper.watchface.dsl.scope.text.PartTextScope
 
 /**
  * レイアウトに関する子を持てる
- * TODO一覧
- *         <PartAnimatedImage ... />
  */
 interface HasWatchFaceLayoutElement : WatchFaceHasChildElement
 
@@ -260,6 +259,44 @@ fun HasWatchFaceLayoutElement.AnalogClock(
         scaleY = scaleY,
         renderMode = renderMode,
         tintColor = tintColor,
+    )
+    block(scope)
+    addChild(scope)
+}
+
+@Suppress("FunctionName")
+fun HasWatchFaceLayoutElement.PartAnimatedImage(
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+    name: String? = null,
+    angle: Float? = null,
+    pivotX: Float? = null,
+    pivotY: Float? = null,
+    alpha: Int? = null,
+    scaleX: Float? = null,
+    scaleY: Float? = null,
+    renderMode: RenderMode? = null,
+    tintColor: String? = null,
+    blendMode: String? = null,
+    block: PartAnimatedImageScope.() -> Unit,
+) {
+    val scope = PartAnimatedImageScope(
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        name = name,
+        angle = angle,
+        pivotX = pivotX,
+        pivotY = pivotY,
+        alpha = alpha,
+        scaleX = scaleX,
+        scaleY = scaleY,
+        renderMode = renderMode,
+        tintColor = tintColor,
+        blendMode = blendMode,
     )
     block(scope)
     addChild(scope)

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/HasWatchFaceLayoutElement.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/HasWatchFaceLayoutElement.kt
@@ -3,6 +3,7 @@ package net.matsudamper.watchface.dsl.scope
 import net.matsudamper.watchface.dsl.element.ComplicationSlotSupportedType
 import net.matsudamper.watchface.dsl.element.RenderMode
 import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.clock.AnalogClockScope
 import net.matsudamper.watchface.dsl.scope.clock.DigitalClockScope
 import net.matsudamper.watchface.dsl.scope.complication.ComplicationSlotScope
 import net.matsudamper.watchface.dsl.scope.draw.PartDrawScope
@@ -12,9 +13,7 @@ import net.matsudamper.watchface.dsl.scope.text.PartTextScope
 /**
  * レイアウトに関する子を持てる
  * TODO一覧
- *         <PartImage ... />
  *         <PartAnimatedImage ... />
- *         <AnalogClock ... />
  */
 interface HasWatchFaceLayoutElement : WatchFaceHasChildElement
 
@@ -226,6 +225,40 @@ fun HasWatchFaceLayoutElement.ComplicationSlot(
         scaleY = scaleY,
         supportedTypes = supportedTypes,
         isCustomizable = isCustomizable,
+        tintColor = tintColor,
+    )
+    block(scope)
+    addChild(scope)
+}
+
+@Suppress("FunctionName")
+fun HasWatchFaceLayoutElement.AnalogClock(
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+    pivotX: Float? = null,
+    pivotY: Float? = null,
+    angle: Float? = null,
+    alpha: Int? = null,
+    scaleX: Float? = null,
+    scaleY: Float? = null,
+    renderMode: RenderMode? = null,
+    tintColor: String? = null,
+    block: AnalogClockScope.() -> Unit,
+) {
+    val scope = AnalogClockScope(
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        pivotX = pivotX,
+        pivotY = pivotY,
+        angle = angle,
+        alpha = alpha,
+        scaleX = scaleX,
+        scaleY = scaleY,
+        renderMode = renderMode,
         tintColor = tintColor,
     )
     block(scope)

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/animatedimage/PartAnimatedImageScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/animatedimage/PartAnimatedImageScope.kt
@@ -1,0 +1,247 @@
+package net.matsudamper.watchface.dsl.scope.animatedimage
+
+import net.matsudamper.watchface.dsl.element.AnimatedImageFormat
+import net.matsudamper.watchface.dsl.element.AnimationChangeDirection
+import net.matsudamper.watchface.dsl.element.AnimationPlayEvent
+import net.matsudamper.watchface.dsl.element.RenderMode
+import net.matsudamper.watchface.dsl.element.WatchFaceElement
+import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
+
+@WatchFaceDSLMarker
+class PartAnimatedImageScope(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val name: String?,
+    val angle: Float?,
+    val pivotX: Float?,
+    val pivotY: Float?,
+    val alpha: Int?,
+    val scaleX: Float?,
+    val scaleY: Float?,
+    val renderMode: RenderMode?,
+    val tintColor: String?,
+    val blendMode: String?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "PartAnimatedImage"
+    override val attributes: Map<String, String?> = mapOf(
+        "x" to x.toString(),
+        "y" to y.toString(),
+        "width" to width.toString(),
+        "height" to height.toString(),
+        "name" to name,
+        "angle" to angle?.toString(),
+        "pivotX" to pivotX?.toString(),
+        "pivotY" to pivotY?.toString(),
+        "alpha" to alpha?.toString(),
+        "scaleX" to scaleX?.toString(),
+        "scaleY" to scaleY?.toString(),
+        "renderMode" to renderMode?.value,
+        "tintColor" to tintColor,
+        "blendMode" to blendMode,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+
+    fun AnimationController(
+        play: AnimationPlayEvent,
+        delayPlay: Float? = null,
+        delayRepeat: Float? = null,
+        repeat: Boolean? = null,
+        loopCount: Int? = null,
+        resumePlayBack: Boolean? = null,
+        beforePlaying: String? = null,
+        afterPlaying: String? = null,
+    ) {
+        children.add(
+            AnimationControllerScope(
+                play = play,
+                delayPlay = delayPlay,
+                delayRepeat = delayRepeat,
+                repeat = repeat,
+                loopCount = loopCount,
+                resumePlayBack = resumePlayBack,
+                beforePlaying = beforePlaying,
+                afterPlaying = afterPlaying,
+            )
+        )
+    }
+
+    fun AnimatedImage(
+        resource: String,
+        format: AnimatedImageFormat,
+        thumbnail: String? = null,
+    ) {
+        children.add(
+            AnimatedImageScope(
+                resource = resource,
+                format = format,
+                thumbnail = thumbnail,
+            )
+        )
+    }
+
+    fun AnimatedImages(
+        change: AnimationPlayEvent? = null,
+        changeDirection: AnimationChangeDirection? = null,
+        block: AnimatedImagesScope.() -> Unit,
+    ) {
+        children.add(AnimatedImagesScope(change = change, changeDirection = changeDirection).apply(block))
+    }
+
+    fun SequenceImage(
+        loopCount: Int? = null,
+        frameRate: Int? = null,
+        thumbnail: String? = null,
+        block: SequenceImageScope.() -> Unit,
+    ) {
+        children.add(
+            SequenceImageScope(
+                loopCount = loopCount,
+                frameRate = frameRate,
+                thumbnail = thumbnail,
+            ).apply(block)
+        )
+    }
+
+    fun Thumbnail(resource: String) {
+        children.add(ThumbnailScope(resource = resource))
+    }
+}
+
+class AnimationControllerScope(
+    play: AnimationPlayEvent,
+    delayPlay: Float?,
+    delayRepeat: Float?,
+    repeat: Boolean?,
+    loopCount: Int?,
+    resumePlayBack: Boolean?,
+    beforePlaying: String?,
+    afterPlaying: String?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "AnimationController"
+    override val attributes: Map<String, String?> = mapOf(
+        "play" to play.value,
+        "delayPlay" to delayPlay?.toString(),
+        "delayRepeat" to delayRepeat?.toString(),
+        "repeat" to repeat?.toString()?.uppercase(),
+        "loopCount" to loopCount?.toString(),
+        "resumePlayBack" to resumePlayBack?.toString()?.uppercase(),
+        "beforePlaying" to beforePlaying,
+        "afterPlaying" to afterPlaying,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        throw UnsupportedOperationException()
+    }
+}
+
+class AnimatedImageScope(
+    resource: String,
+    format: AnimatedImageFormat,
+    thumbnail: String?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "AnimatedImage"
+    override val attributes: Map<String, String?> = mapOf(
+        "resource" to resource,
+        "format" to format.value,
+        "thumbnail" to thumbnail,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        throw UnsupportedOperationException()
+    }
+}
+
+@WatchFaceDSLMarker
+class AnimatedImagesScope(
+    change: AnimationPlayEvent?,
+    changeDirection: AnimationChangeDirection?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "AnimatedImages"
+    override val attributes: Map<String, String?> = mapOf(
+        "change" to change?.value,
+        "changeDirection" to changeDirection?.value,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+
+    fun AnimatedImage(
+        resource: String,
+        format: AnimatedImageFormat,
+        thumbnail: String? = null,
+    ) {
+        children.add(
+            AnimatedImageScope(
+                resource = resource,
+                format = format,
+                thumbnail = thumbnail,
+            )
+        )
+    }
+
+    fun SequenceImage(
+        loopCount: Int? = null,
+        frameRate: Int? = null,
+        thumbnail: String? = null,
+        block: SequenceImageScope.() -> Unit,
+    ) {
+        children.add(
+            SequenceImageScope(
+                loopCount = loopCount,
+                frameRate = frameRate,
+                thumbnail = thumbnail,
+            ).apply(block)
+        )
+    }
+}
+
+@WatchFaceDSLMarker
+class SequenceImageScope(
+    loopCount: Int?,
+    frameRate: Int?,
+    thumbnail: String?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "SequenceImage"
+    override val attributes: Map<String, String?> = mapOf(
+        "loopCount" to loopCount?.toString(),
+        "frameRate" to frameRate?.toString(),
+        "thumbnail" to thumbnail,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+
+    fun Image(resource: String) {
+        children.add(SequenceFrameScope(resource = resource))
+    }
+}
+
+class SequenceFrameScope(resource: String) : WatchFaceHasChildElement {
+    override val elementName: String = "Image"
+    override val attributes: Map<String, String?> = mapOf(
+        "resource" to resource,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        throw UnsupportedOperationException()
+    }
+}
+
+class ThumbnailScope(resource: String) : WatchFaceHasChildElement {
+    override val elementName: String = "Thumbnail"
+    override val attributes: Map<String, String?> = mapOf(
+        "resource" to resource,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        throw UnsupportedOperationException()
+    }
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/clock/AnalogClockScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/clock/AnalogClockScope.kt
@@ -1,0 +1,144 @@
+package net.matsudamper.watchface.dsl.scope.clock
+
+import net.matsudamper.watchface.dsl.element.RenderMode
+import net.matsudamper.watchface.dsl.element.WatchFaceElement
+import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
+
+@WatchFaceDSLMarker
+class AnalogClockScope(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val pivotX: Float?,
+    val pivotY: Float?,
+    val angle: Float?,
+    val alpha: Int?,
+    val scaleX: Float?,
+    val scaleY: Float?,
+    val renderMode: RenderMode?,
+    val tintColor: String?,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "AnalogClock"
+    override val attributes: Map<String, String?> = mapOf(
+        "x" to x.toString(),
+        "y" to y.toString(),
+        "width" to width.toString(),
+        "height" to height.toString(),
+        "pivotX" to pivotX?.toString(),
+        "pivotY" to pivotY?.toString(),
+        "angle" to angle?.toString(),
+        "alpha" to alpha?.toString(),
+        "scaleX" to scaleX?.toString(),
+        "scaleY" to scaleY?.toString(),
+        "renderMode" to renderMode?.value,
+        "tintColor" to tintColor,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+
+    fun HourHand(
+        resource: String,
+        x: Int? = null,
+        y: Int? = null,
+        width: Int? = null,
+        height: Int? = null,
+        pivotX: Float? = null,
+        pivotY: Float? = null,
+        tintColor: String? = null,
+    ) {
+        children.add(
+            ClockHandScope(
+                elementName = "HourHand",
+                resource = resource,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                pivotX = pivotX,
+                pivotY = pivotY,
+                tintColor = tintColor,
+            )
+        )
+    }
+
+    fun MinuteHand(
+        resource: String,
+        x: Int? = null,
+        y: Int? = null,
+        width: Int? = null,
+        height: Int? = null,
+        pivotX: Float? = null,
+        pivotY: Float? = null,
+        tintColor: String? = null,
+    ) {
+        children.add(
+            ClockHandScope(
+                elementName = "MinuteHand",
+                resource = resource,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                pivotX = pivotX,
+                pivotY = pivotY,
+                tintColor = tintColor,
+            )
+        )
+    }
+
+    fun SecondHand(
+        resource: String,
+        x: Int? = null,
+        y: Int? = null,
+        width: Int? = null,
+        height: Int? = null,
+        pivotX: Float? = null,
+        pivotY: Float? = null,
+        tintColor: String? = null,
+    ) {
+        children.add(
+            ClockHandScope(
+                elementName = "SecondHand",
+                resource = resource,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                pivotX = pivotX,
+                pivotY = pivotY,
+                tintColor = tintColor,
+            )
+        )
+    }
+}
+
+internal class ClockHandScope(
+    override val elementName: String,
+    resource: String,
+    x: Int?,
+    y: Int?,
+    width: Int?,
+    height: Int?,
+    pivotX: Float?,
+    pivotY: Float?,
+    tintColor: String?,
+) : WatchFaceHasChildElement {
+    override val attributes: Map<String, String?> = mapOf(
+        "resource" to resource,
+        "x" to x?.toString(),
+        "y" to y?.toString(),
+        "width" to width?.toString(),
+        "height" to height?.toString(),
+        "pivotX" to pivotX?.toString(),
+        "pivotY" to pivotY?.toString(),
+        "tintColor" to tintColor,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/EllipseScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/EllipseScope.kt
@@ -1,0 +1,25 @@
+package net.matsudamper.watchface.dsl.scope.draw
+
+import net.matsudamper.watchface.dsl.element.WatchFaceElement
+import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
+
+@WatchFaceDSLMarker
+class EllipseScope(
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+) : WatchFaceHasChildElement, ShapeScope {
+    override val elementName: String = "Ellipse"
+    override val attributes: Map<String, String?> = mapOf(
+        "x" to x.toString(),
+        "y" to y.toString(),
+        "width" to width.toString(),
+        "height" to height.toString(),
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/FillScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/FillScope.kt
@@ -1,0 +1,27 @@
+package net.matsudamper.watchface.dsl.scope.draw
+
+import net.matsudamper.watchface.dsl.element.WatchFaceElement
+import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
+
+@WatchFaceDSLMarker
+class FillScope(
+    color: String,
+) : WatchFaceHasChildElement {
+    override val elementName: String = "Fill"
+    override val attributes: Map<String, String?> = mapOf(
+        "color" to color,
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+}
+
+@Suppress("FunctionName")
+fun ShapeScope.Fill(
+    color: String,
+    block: FillScope.() -> Unit = {},
+) {
+    addChild(FillScope(color = color).apply(block))
+}

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/PartDrawScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/PartDrawScope.kt
@@ -6,7 +6,6 @@ import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
 import net.matsudamper.watchface.dsl.element.WatchFaceElement
 import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
 import net.matsudamper.watchface.dsl.scope.HasWatchFaceLayoutElement
-import javax.sound.sampled.Line
 
 @WatchFaceDSLMarker
 @Suppress("FunctionName")
@@ -98,6 +97,40 @@ class PartDrawScope(
             height = height,
             cornerRadiusX = cornerRadiusX,
             cornerRadiusY = cornerRadiusY,
+        )
+        block(scope)
+        children.add(scope)
+    }
+
+    fun Rectangle(
+        x: Float,
+        y: Float,
+        width: Float,
+        height: Float,
+        block: RectangleScope.() -> Unit,
+    ) {
+        val scope = RectangleScope(
+            x = x,
+            y = y,
+            width = width,
+            height = height,
+        )
+        block(scope)
+        children.add(scope)
+    }
+
+    fun Ellipse(
+        x: Float,
+        y: Float,
+        width: Float,
+        height: Float,
+        block: EllipseScope.() -> Unit,
+    ) {
+        val scope = EllipseScope(
+            x = x,
+            y = y,
+            width = width,
+            height = height,
         )
         block(scope)
         children.add(scope)

--- a/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/RectangleScope.kt
+++ b/build-logic/src/main/kotlin/net/matsudamper/watchface/dsl/scope/draw/RectangleScope.kt
@@ -1,0 +1,25 @@
+package net.matsudamper.watchface.dsl.scope.draw
+
+import net.matsudamper.watchface.dsl.element.WatchFaceElement
+import net.matsudamper.watchface.dsl.element.WatchFaceHasChildElement
+import net.matsudamper.watchface.dsl.scope.WatchFaceDSLMarker
+
+@WatchFaceDSLMarker
+class RectangleScope(
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+) : WatchFaceHasChildElement, ShapeScope {
+    override val elementName: String = "Rectangle"
+    override val attributes: Map<String, String?> = mapOf(
+        "x" to x.toString(),
+        "y" to y.toString(),
+        "width" to width.toString(),
+        "height" to height.toString(),
+    )
+    override val children: MutableList<WatchFaceElement> = mutableListOf()
+    override fun addChild(child: WatchFaceElement) {
+        children.add(child)
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds support for analog clock elements and shape drawing capabilities to the watchface DSL, expanding the layout customization options available to developers.

## Key Changes
- **AnalogClock Support**: Added `AnalogClockScope` class with support for hour, minute, and second hands, including positioning, scaling, rotation, and tint color customization
- **Shape Drawing Elements**: Introduced `RectangleScope` and `EllipseScope` for drawing basic shapes with position and dimension attributes
- **Fill Support**: Added `FillScope` to enable color filling of shapes
- **DSL Extensions**: Added `AnalogClock()`, `Rectangle()`, and `Ellipse()` builder functions to `HasWatchFaceLayoutElement` and `PartDrawScope` interfaces
- **Internal Clock Hand Handler**: Created `ClockHandScope` as an internal class to manage individual clock hand elements (hour, minute, second)
- **Documentation Update**: Removed completed TODO items from the interface documentation

## Implementation Details
- `AnalogClockScope` supports standard transformation attributes (pivotX, pivotY, angle, scaleX, scaleY, alpha) and rendering options (renderMode, tintColor)
- Clock hands are added as child elements through dedicated builder functions (`HourHand()`, `MinuteHand()`, `SecondHand()`)
- Shape scopes implement a new `ShapeScope` interface to enable fill operations
- Removed unused import (`javax.sound.sampled.Line`) from `PartDrawScope`

https://claude.ai/code/session_012oxrKph1w5BZpmjPF9LaYE