### PR TITLE
chore: CLAUDE.md を @AGENTS.md の1行importに統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary
- `CLAUDE.md` を通常ファイルにし、内容を `@AGENTS.md`（1行・末尾改行）のみに統一
- symlink / AGENTS.md 全文コピーは使わない
- `AGENTS.md` 本体は変更なし

## Test plan
- [ ] `CLAUDE.md` が通常ファイルで `@AGENTS.md` のみであること
