### PR TITLE
chore: Paparazzi を docs/agent-paparazzi.md に分離

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ WearOS向けウォッチフェイス。DSLでWatch Face Format XMLを生成。
 
 例:
 - `docs/agent-kotlin.md` — Kotlin 詳細スタイル
-- `docs/agent-compose.md` — Compose / UiState / Paparazzi
+- `docs/agent-compose.md` — Compose / UiState
+- `docs/agent-paparazzi.md` — Paparazzi
 - 既存の `docs/compose-guidelines.md` / `docs/coding_style.md` などリポ固有の詳細ガイド
 
 ## 言語


### PR DESCRIPTION
## Summary
- 共通ブロックの docs 参照から Paparazzi を分離し、`docs/agent-paparazzi.md` 行を追加
- 存在するリポでは `docs/agent-compose.md` から Paparazzi 記述を削除
- Paparazzi 利用リポのみ `docs/agent-paparazzi.md` を新規追加
- リポ固有セクションの Paparazzi コマンドは変更なし

## Test plan
- [ ] AGENTS.md の docs 例ラベルを目視確認
- [ ] agent-compose / agent-paparazzi の有無がリポ方針どおりか確認
