### PR TITLE
CodeRabbitのDocstring Coverageを無効化

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  pre_merge_checks:
+    docstrings:
+      mode: off


### PR DESCRIPTION
CodeRabbitのDocstring Coverageチェックを無効化します。